### PR TITLE
🐛 Fix Docker build failure: Replace firefox-esr with firefox for Ubuntu 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update && apt-get install -y \
     # File management
     thunar \
     # Additional desktop utilities
-    firefox-esr \
+    firefox \
     gedit \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -14,6 +14,11 @@ E: Unable to locate package [package-name]
 - Try alternative packages
 - Update the Dockerfile to remove problematic packages
 
+**Common Package Issues**:
+- `file-manager-actions` → Remove (not available in Ubuntu 22.04)
+- `firefox-esr` → Use `firefox` instead
+- Always verify package names for the specific Ubuntu version
+
 #### Wine Configuration Issues
 ```
 Wine configuration failed

--- a/scripts/verify-packages.sh
+++ b/scripts/verify-packages.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Package verification script for Ubuntu 22.04
+# This script checks if all packages in the Dockerfile are available
+
+echo "🔍 Verifying package availability for Ubuntu 22.04..."
+
+# List of packages from Dockerfile
+PACKAGES=(
+    "xfce4"
+    "xfce4-goodies"
+    "tightvncserver"
+    "novnc"
+    "websockify"
+    "wine"
+    "winetricks"
+    "cabextract"
+    "winbind"
+    "wget"
+    "curl"
+    "unzip"
+    "supervisor"
+    "nginx"
+    "x11-utils"
+    "x11-apps"
+    "pulseaudio"
+    "fonts-liberation"
+    "fonts-dejavu-core"
+    "psmisc"
+    "netcat-openbsd"
+    "thunar"
+    "firefox"
+    "gedit"
+)
+
+# Function to check if package exists
+check_package() {
+    local package=$1
+    echo -n "Checking $package... "
+    
+    if docker run --rm ubuntu:22.04 bash -c "apt update -qq && apt-cache show $package >/dev/null 2>&1"; then
+        echo "✅ Available"
+        return 0
+    else
+        echo "❌ Not found"
+        return 1
+    fi
+}
+
+# Check if Docker is available
+if ! command -v docker &> /dev/null; then
+    echo "❌ Docker is not available. Cannot verify packages."
+    echo "💡 This script requires Docker to test package availability."
+    exit 1
+fi
+
+# Check each package
+failed_packages=()
+for package in "${PACKAGES[@]}"; do
+    if ! check_package "$package"; then
+        failed_packages+=("$package")
+    fi
+done
+
+# Summary
+echo ""
+echo "📊 Package Verification Summary:"
+echo "Total packages: ${#PACKAGES[@]}"
+echo "Failed packages: ${#failed_packages[@]}"
+
+if [ ${#failed_packages[@]} -eq 0 ]; then
+    echo "🎉 All packages are available in Ubuntu 22.04!"
+    exit 0
+else
+    echo "❌ The following packages are not available:"
+    for package in "${failed_packages[@]}"; do
+        echo "  - $package"
+    done
+    echo ""
+    echo "💡 Consider removing or replacing these packages in the Dockerfile."
+    exit 1
+fi


### PR DESCRIPTION
## 🐛 Bug Fix: Docker Build Package Issues

### Problem
Docker build was failing with:
```
E: Unable to locate package firefox-esr
```

### Root Cause
The `firefox-esr` package is not available in Ubuntu 22.04 repositories. Ubuntu 22.04 uses the standard `firefox` package instead.

### 🔧 Changes Made

#### 1. Fixed Package Name in Dockerfile
- **Before**: `firefox-esr`
- **After**: `firefox`

#### 2. Updated Troubleshooting Documentation
- Added section for common package name issues
- Documented `firefox-esr` → `firefox` change
- Added guidance for verifying package names

#### 3. Added Package Verification Script
- New script: `scripts/verify-packages.sh`
- Tests all Dockerfile packages against Ubuntu 22.04
- Helps prevent future package availability issues
- Provides clear feedback on missing packages

### 🧪 Testing
- ✅ Verified `firefox` package is available in Ubuntu 22.04
- ✅ Updated troubleshooting guide with solution
- ✅ Added verification script for future package checks

### 📋 Files Changed
- `Dockerfile` - Fixed firefox package name
- `TROUBLESHOOTING.md` - Added package issue documentation
- `scripts/verify-packages.sh` - New verification tool

### 🚀 Impact
- ✅ Resolves Docker build failures
- ✅ Prevents similar package issues in the future
- ✅ Improves developer experience with better documentation
- ✅ Maintains all functionality (Firefox browser still available)

### 🔍 Related Issues
This addresses the build error reported where the Docker build process fails at step 2/18 due to the unavailable `firefox-esr` package.

### 📝 Notes
- This is a minimal, targeted fix that only changes the package name
- All other functionality remains unchanged
- The verification script can be used to test package availability before builds

@moonsip1224 can click here to [continue refining the PR](https://app.all-hands.dev/2bda3864891e466986a5310d3981d2c9)